### PR TITLE
Add TalentBridge static site (HTML/CSS/JS) and smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# project
+# TalentBridge MVP
+
+一个 Upwork 风格的简化演示站点：
+
+- 企业可以发布任务（标题、预算、技能、描述）
+- 个人可以上传简历（姓名、职位、技能、简介）
+- 所有数据保存在浏览器 `localStorage`
+
+## 本地运行
+
+```bash
+python3 -m http.server 8000
+```
+
+然后访问：<http://localhost:8000>
+
+## 测试
+
+```bash
+python3 tests/smoke_test.py
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TalentBridge - 企业任务与人才简历平台</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <div class="hero__content">
+        <p class="badge">Upwork 风格 MVP</p>
+        <h1>TalentBridge</h1>
+        <p class="subtitle">企业发布任务，个人上传简历，快速完成需求与人才匹配。</p>
+      </div>
+    </header>
+
+    <main class="container">
+      <section class="grid two-cols">
+        <article class="card">
+          <h2>企业发布任务</h2>
+          <form id="jobForm" class="form">
+            <label>
+              任务标题
+              <input name="title" required maxlength="80" placeholder="例如：开发官网落地页" />
+            </label>
+            <label>
+              预算（人民币）
+              <input name="budget" type="number" min="0" required placeholder="例如：5000" />
+            </label>
+            <label>
+              技能要求
+              <input name="skills" required placeholder="例如：React, UI 设计, SEO" />
+            </label>
+            <label>
+              任务描述
+              <textarea name="description" required rows="4" placeholder="描述项目背景、交付时间和验收标准"></textarea>
+            </label>
+            <button type="submit">发布任务</button>
+          </form>
+        </article>
+
+        <article class="card">
+          <h2>个人上传简历</h2>
+          <form id="resumeForm" class="form">
+            <label>
+              姓名
+              <input name="name" required maxlength="40" placeholder="你的姓名" />
+            </label>
+            <label>
+              职位方向
+              <input name="role" required placeholder="例如：前端开发工程师" />
+            </label>
+            <label>
+              核心技能
+              <input name="skills" required placeholder="例如：Vue, TypeScript, Node.js" />
+            </label>
+            <label>
+              个人简介
+              <textarea name="summary" required rows="4" placeholder="简要介绍项目经验与优势"></textarea>
+            </label>
+            <button type="submit">上传简历</button>
+          </form>
+        </article>
+      </section>
+
+      <section class="grid two-cols">
+        <article class="card">
+          <div class="section-header">
+            <h2>最新任务</h2>
+            <button id="clearJobs" class="ghost">清空任务</button>
+          </div>
+          <div id="jobList" class="list"></div>
+        </article>
+
+        <article class="card">
+          <div class="section-header">
+            <h2>人才简历</h2>
+            <button id="clearResumes" class="ghost">清空简历</button>
+          </div>
+          <div id="resumeList" class="list"></div>
+        </article>
+      </section>
+    </main>
+
+    <footer class="footer">MVP 示例，仅用于功能演示。</footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,110 @@
+const storageKeys = {
+  jobs: "talentbridge_jobs",
+  resumes: "talentbridge_resumes",
+};
+
+function load(key) {
+  return JSON.parse(localStorage.getItem(key) ?? "[]");
+}
+
+function save(key, data) {
+  localStorage.setItem(key, JSON.stringify(data));
+}
+
+function renderCards(container, items, renderer) {
+  container.innerHTML = "";
+
+  if (items.length === 0) {
+    container.innerHTML = '<p class="empty">暂无数据，先提交一条吧。</p>';
+    return;
+  }
+
+  for (const item of items) {
+    const card = document.createElement("article");
+    card.className = "item";
+    card.innerHTML = renderer(item);
+    container.append(card);
+  }
+}
+
+function init() {
+  const jobForm = document.getElementById("jobForm");
+  const resumeForm = document.getElementById("resumeForm");
+  const jobList = document.getElementById("jobList");
+  const resumeList = document.getElementById("resumeList");
+
+  let jobs = load(storageKeys.jobs);
+  let resumes = load(storageKeys.resumes);
+
+  const render = () => {
+    renderCards(
+      jobList,
+      jobs,
+      (job) => `
+        <h3>${job.title}</h3>
+        <p class="meta">预算：¥${Number(job.budget).toLocaleString()} · 技能：${job.skills}</p>
+        <p>${job.description}</p>
+      `,
+    );
+
+    renderCards(
+      resumeList,
+      resumes,
+      (resume) => `
+        <h3>${resume.name} · ${resume.role}</h3>
+        <p class="meta">技能：${resume.skills}</p>
+        <p>${resume.summary}</p>
+      `,
+    );
+  };
+
+  jobForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const formData = new FormData(jobForm);
+
+    const newJob = {
+      title: formData.get("title")?.toString().trim(),
+      budget: formData.get("budget")?.toString().trim(),
+      skills: formData.get("skills")?.toString().trim(),
+      description: formData.get("description")?.toString().trim(),
+    };
+
+    jobs = [newJob, ...jobs];
+    save(storageKeys.jobs, jobs);
+    jobForm.reset();
+    render();
+  });
+
+  resumeForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const formData = new FormData(resumeForm);
+
+    const newResume = {
+      name: formData.get("name")?.toString().trim(),
+      role: formData.get("role")?.toString().trim(),
+      skills: formData.get("skills")?.toString().trim(),
+      summary: formData.get("summary")?.toString().trim(),
+    };
+
+    resumes = [newResume, ...resumes];
+    save(storageKeys.resumes, resumes);
+    resumeForm.reset();
+    render();
+  });
+
+  document.getElementById("clearJobs").addEventListener("click", () => {
+    jobs = [];
+    save(storageKeys.jobs, jobs);
+    render();
+  });
+
+  document.getElementById("clearResumes").addEventListener("click", () => {
+    resumes = [];
+    save(storageKeys.resumes, resumes);
+    render();
+  });
+
+  render();
+}
+
+init();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,171 @@
+:root {
+  color-scheme: light;
+  --bg: #f5f7fb;
+  --card: #ffffff;
+  --text: #1f2937;
+  --muted: #6b7280;
+  --primary: #2563eb;
+  --primary-dark: #1d4ed8;
+  --border: #e5e7eb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "PingFang SC", "Microsoft YaHei", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.hero {
+  background: linear-gradient(120deg, #1d4ed8, #3b82f6);
+  color: #fff;
+  padding: 3rem 1.25rem;
+  text-align: center;
+}
+
+.badge {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+h1 {
+  margin: 0.5rem 0;
+  font-size: 2rem;
+}
+
+.subtitle {
+  margin: 0;
+  opacity: 0.95;
+}
+
+.container {
+  max-width: 1100px;
+  margin: -1.5rem auto 2rem;
+  padding: 0 1rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.two-cols {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  margin-bottom: 1rem;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem;
+  box-shadow: 0 4px 15px rgba(17, 24, 39, 0.06);
+}
+
+h2 {
+  margin-top: 0.25rem;
+  margin-bottom: 1rem;
+  font-size: 1.1rem;
+}
+
+.form {
+  display: grid;
+  gap: 0.8rem;
+}
+
+label {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+}
+
+input,
+textarea {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.65rem 0.75rem;
+  font: inherit;
+}
+
+input:focus,
+textarea:focus {
+  border-color: var(--primary);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+button {
+  border: none;
+  border-radius: 10px;
+  padding: 0.65rem 0.9rem;
+  background: var(--primary);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+button:hover {
+  background: var(--primary-dark);
+}
+
+button.ghost {
+  background: #eef2ff;
+  color: #3730a3;
+}
+
+button.ghost:hover {
+  background: #e0e7ff;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.item {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background: #fcfdff;
+}
+
+.item h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.meta {
+  margin: 0.3rem 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.item p {
+  margin: 0;
+  line-height: 1.5;
+  font-size: 0.92rem;
+}
+
+.empty {
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.footer {
+  text-align: center;
+  color: var(--muted);
+  padding: 1rem;
+  font-size: 0.85rem;
+}

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Basic smoke tests for the TalentBridge static site."""
+
+from __future__ import annotations
+
+import http.client
+import subprocess
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HOST = "127.0.0.1"
+PORT = 8765
+
+
+def wait_for_server(timeout_seconds: float = 5.0) -> None:
+    deadline = time.time() + timeout_seconds
+    last_error: Exception | None = None
+    while time.time() < deadline:
+        try:
+            conn = http.client.HTTPConnection(HOST, PORT, timeout=1)
+            conn.request("GET", "/")
+            response = conn.getresponse()
+            response.read()
+            if response.status == 200:
+                return
+        except Exception as error:  # noqa: BLE001 - test helper
+            last_error = error
+        time.sleep(0.1)
+    raise RuntimeError(f"server not ready: {last_error}")
+
+
+def request(path: str) -> tuple[int, str]:
+    conn = http.client.HTTPConnection(HOST, PORT, timeout=3)
+    conn.request("GET", path)
+    response = conn.getresponse()
+    body = response.read().decode("utf-8", errors="replace")
+    return response.status, body
+
+
+def run() -> None:
+    server = subprocess.Popen(
+        ["python3", "-m", "http.server", str(PORT)],
+        cwd=ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    try:
+        wait_for_server()
+
+        status, index = request("/")
+        assert status == 200, f"expected 200 for /, got {status}"
+        assert "TalentBridge" in index, "index page should include site title"
+        assert "企业发布任务" in index, "index page should include employer section"
+        assert "个人上传简历" in index, "index page should include candidate section"
+
+        status, css = request("/styles.css")
+        assert status == 200, f"expected 200 for /styles.css, got {status}"
+        assert ".card" in css, "styles.css should contain card styles"
+
+        status, script = request("/script.js")
+        assert status == 200, f"expected 200 for /script.js, got {status}"
+        assert "localStorage" in script, "script.js should include persistence logic"
+
+        print("smoke tests passed")
+    finally:
+        server.terminate()
+        try:
+            server.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            server.kill()
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
### Motivation

- Provide a minimal client-side MVP for TalentBridge so the prototype can be served as a static site.
- Add a repeatable automated smoke test to catch regressions and verify that core assets and content are served correctly.
- Make it easy for contributors to run the smoke test locally via a documented command in `README.md`.

### Description

- Add `index.html` with the landing page and forms for posting jobs and uploading resumes.
- Add `styles.css` with layout and component styles and `script.js` implementing client-side persistence using `localStorage` and rendering logic.
- Add `tests/smoke_test.py` which starts a local static server and validates `/`, `/styles.css`, and `/script.js` responses and key content strings like `TalentBridge`, `企业发布任务`, and `个人上传简历`.
- Update `README.md` to include `python3 tests/smoke_test.py` as the smoke-test command and basic run instructions.

### Testing

- Ran the smoke test with `python3 tests/smoke_test.py`, which started the server and completed successfully (`smoke tests passed`).
- Performed a syntax check on `script.js` with `node --check script.js`, which finished with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69930a549bac8325bd007d374289ebb9)