### PR TITLE
feat: add browser-playable Snake game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # project
+
+一个可直接在浏览器打开运行的贪吃蛇小游戏。
+
+## 运行方式
+
+- 直接双击打开 `index.html`；或
+- 在项目目录启动静态服务器：
+
+```bash
+python3 -m http.server 8000
+```
+
+然后访问 `http://localhost:8000`。

--- a/index.html
+++ b/index.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>贪吃蛇</title>
+  <style>
+    :root { color-scheme: dark; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background: #111827;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      color: #e5e7eb;
+    }
+    .game-wrap {
+      width: min(92vw, 520px);
+      display: grid;
+      gap: 12px;
+      justify-items: center;
+    }
+    canvas {
+      width: 100%;
+      max-width: 500px;
+      border: 2px solid #374151;
+      background: #030712;
+      border-radius: 10px;
+      box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
+    }
+    .panel {
+      width: 100%;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-size: 16px;
+    }
+    button {
+      border: none;
+      border-radius: 8px;
+      padding: 8px 14px;
+      background: #10b981;
+      color: #052e16;
+      font-weight: 700;
+      cursor: pointer;
+    }
+    button:hover { filter: brightness(1.05); }
+    .tips { font-size: 14px; opacity: 0.85; }
+  </style>
+</head>
+<body>
+  <main class="game-wrap">
+    <h1>贪吃蛇 🐍</h1>
+    <div class="panel">
+      <span>分数：<strong id="score">0</strong></span>
+      <button id="restart">重新开始</button>
+    </div>
+    <canvas id="board" width="500" height="500" aria-label="snake game board"></canvas>
+    <p class="tips">方向键 / WASD 控制移动，吃到红色食物加分。</p>
+  </main>
+
+  <script>
+    const canvas = document.getElementById('board');
+    const ctx = canvas.getContext('2d');
+    const scoreEl = document.getElementById('score');
+    const restartBtn = document.getElementById('restart');
+
+    const gridSize = 20;
+    const tileCount = canvas.width / gridSize;
+    let snake;
+    let direction;
+    let queuedDirection;
+    let food;
+    let score;
+    let gameOver;
+
+    function resetGame() {
+      snake = [{ x: 10, y: 10 }];
+      direction = { x: 1, y: 0 };
+      queuedDirection = { ...direction };
+      food = randomFood();
+      score = 0;
+      gameOver = false;
+      scoreEl.textContent = score;
+      draw();
+    }
+
+    function randomFood() {
+      let pos;
+      do {
+        pos = {
+          x: Math.floor(Math.random() * tileCount),
+          y: Math.floor(Math.random() * tileCount)
+        };
+      } while (snake?.some(part => part.x === pos.x && part.y === pos.y));
+      return pos;
+    }
+
+    function update() {
+      if (gameOver) return;
+
+      direction = queuedDirection;
+      const head = {
+        x: snake[0].x + direction.x,
+        y: snake[0].y + direction.y
+      };
+
+      const hitWall = head.x < 0 || head.x >= tileCount || head.y < 0 || head.y >= tileCount;
+      const hitSelf = snake.some(part => part.x === head.x && part.y === head.y);
+
+      if (hitWall || hitSelf) {
+        gameOver = true;
+        draw();
+        return;
+      }
+
+      snake.unshift(head);
+
+      if (head.x === food.x && head.y === food.y) {
+        score += 10;
+        scoreEl.textContent = score;
+        food = randomFood();
+      } else {
+        snake.pop();
+      }
+
+      draw();
+    }
+
+    function drawGrid() {
+      ctx.strokeStyle = 'rgba(255,255,255,0.06)';
+      ctx.lineWidth = 1;
+      for (let i = 0; i <= tileCount; i++) {
+        const p = i * gridSize;
+        ctx.beginPath();
+        ctx.moveTo(p, 0);
+        ctx.lineTo(p, canvas.height);
+        ctx.stroke();
+
+        ctx.beginPath();
+        ctx.moveTo(0, p);
+        ctx.lineTo(canvas.width, p);
+        ctx.stroke();
+      }
+    }
+
+    function draw() {
+      ctx.fillStyle = '#030712';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      drawGrid();
+
+      ctx.fillStyle = '#ef4444';
+      ctx.fillRect(food.x * gridSize + 2, food.y * gridSize + 2, gridSize - 4, gridSize - 4);
+
+      snake.forEach((part, idx) => {
+        ctx.fillStyle = idx === 0 ? '#22c55e' : '#16a34a';
+        ctx.fillRect(part.x * gridSize + 2, part.y * gridSize + 2, gridSize - 4, gridSize - 4);
+      });
+
+      if (gameOver) {
+        ctx.fillStyle = 'rgba(0,0,0,0.5)';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = '#f9fafb';
+        ctx.font = 'bold 38px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText('游戏结束', canvas.width / 2, canvas.height / 2 - 8);
+        ctx.font = '20px sans-serif';
+        ctx.fillText('按“重新开始”再来一局', canvas.width / 2, canvas.height / 2 + 30);
+      }
+    }
+
+    function changeDirection(x, y) {
+      if (x === -direction.x && y === -direction.y) return;
+      queuedDirection = { x, y };
+    }
+
+    window.addEventListener('keydown', (e) => {
+      const key = e.key.toLowerCase();
+      if (['arrowup', 'arrowdown', 'arrowleft', 'arrowright', 'w', 'a', 's', 'd'].includes(key)) {
+        e.preventDefault();
+      }
+
+      if (key === 'arrowup' || key === 'w') changeDirection(0, -1);
+      if (key === 'arrowdown' || key === 's') changeDirection(0, 1);
+      if (key === 'arrowleft' || key === 'a') changeDirection(-1, 0);
+      if (key === 'arrowright' || key === 'd') changeDirection(1, 0);
+    });
+
+    restartBtn.addEventListener('click', resetGame);
+
+    resetGame();
+    setInterval(update, 120);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation

- 提供一个可直接在浏览器打开的演示，展示一个完整的贪吃蛇小游戏并方便本地试玩和演示。 

### Description

- 新增 `index.html`，基于 Canvas 实现棋盘渲染、游戏循环（`setInterval(update, 120)`）、格子逻辑（`gridSize` / `tileCount`）和网格绘制函数 `drawGrid()`。 
- 在 `index.html` 中实现蛇的移动与生长、墙体与自撞检测、`randomFood()`（确保食物不出现在蛇身上）、分数更新以及游戏结束遮罩与 `重新开始` 按钮。 
- 支持键盘方向键与 `W/A/S/D` 双套控制并阻止默认滚动行为以改善游玩体验（键盘事件处理在 `window.addEventListener('keydown', ...)` 中）。 
- 更新 `README.md`，增加如何直接打开页面或使用 `python3 -m http.server 8000` 启动本地静态服务器的运行说明。 

### Testing

- 已运行命令 `python3 -m http.server --help >/dev/null && echo ok`，返回 `ok` 表明本地静态服务器命令可用（自动化检查通过）。
- 项目中未新增单元测试或自动化测试用例。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12e6f3d3288325a85a3ba7d34352d1)